### PR TITLE
Fix error when 'rule.selectors' is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ module.exports = function(source) {
             }).join('; ');
         }
 
-        rule.selectors.forEach(function(selector) {
-            rules[selector] = inline;
-        });
+        if(rule.selectors) {
+            rule.selectors.forEach(function(selector) {
+                rules[selector] = inline;
+            });
+        }
     });
 
     return rules;


### PR DESCRIPTION
Hi, I hit a problem where a stylesheet rule (as parsed by `css`) does not always contain a `selectors` array. A comment being the most common:

```
Module build failed: TypeError: Cannot read property 'forEach' of undefined
```

This loader currently throws an error when it hits a rule with no selectors; this fixes that by just checking if they exist.
